### PR TITLE
Android: Support show through in dark mode

### DIFF
--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -687,7 +687,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
         this.cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                webView.getView().setBackgroundColor(Color.argb(1, 0, 0, 0));
+                webView.getView().setBackgroundColor(Color.TRANSPARENT);
                 showing = true;
                 getStatus(callbackContext);
             }


### PR DESCRIPTION
Support for WebView shining through in dark mode on Android.

`Color.argb(1, 0, 0, 0)` seems to work in light mode but no in dark mode. `Color.TRANSPARENT` works in both modes.

In our Capacitor app dark mode is enabled using the following code:
```
public class MainActivity extends BridgeActivity {
	/**
	 * @link https://forum.ionicframework.com/t/dark-mode-not-working-capacitor/185400/5
	 * @link https://developer.android.com/guide/webapps/dark-theme
	 * @link https://stackoverflow.com/questions/59720952/using-dark-mode-with-a-webview
	 */
	@Override
	public void onResume() {
		super.onResume();

		if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
			int nightModeFlags = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
			WebSettings webSettings = this.bridge.getWebView().getSettings();
			if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
				WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_ON);
			} else {
				WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_OFF);
			}
		}
	}
}
```