### PR TITLE
build(android): Change from "compile" to "implementation" for Gradle 7

### DIFF
--- a/src/android/qrscanner.gradle
+++ b/src/android/qrscanner.gradle
@@ -3,8 +3,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.journeyapps:zxing-android-embedded:3.3.0'
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    implementation 'com.journeyapps:zxing-android-embedded:3.3.0'
+    implementation 'com.android.support:appcompat-v7:23.1.0'
 }
 
 android {


### PR DESCRIPTION
To build with Gradle 7 (which is recommended by Android Studio) it is now required to use "implementation" instead of "compile" in the gradle file "qrscanner.gradle".

For more information, see stackoverflow: https://stackoverflow.com/a/66910991