### PR TITLE
fix(ios): fix camera preview on iOS 15.4

### DIFF
--- a/src/ios/QRScanner.swift
+++ b/src/ios/QRScanner.swift
@@ -330,6 +330,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
     @objc func show(_ command: CDVInvokedUrlCommand) {
         self.webView?.isOpaque = false
         self.webView?.backgroundColor = UIColor.clear
+        self.webView?.scrollView.backgroundColor = UIColor.clear
         self.getStatus(command)
     }
 


### PR DESCRIPTION
iOS 15.4 no longer displays camera previews. See: https://github.com/bitpay/cordova-plugin-qrscanner/issues/371

tl;dr: The inner scroll view needs to get a transparent background.